### PR TITLE
A fix to use 18x512 projected latent spaces

### DIFF
--- a/model.py
+++ b/model.py
@@ -516,8 +516,14 @@ class Generator(nn.Module):
             if inject_index is None:
                 inject_index = random.randint(1, self.n_latent - 1)
 
-            latent = styles[0].unsqueeze(1).repeat(1, inject_index, 1)
-            latent2 = styles[1].unsqueeze(1).repeat(1, self.n_latent - inject_index, 1)
+            if styles[0].ndim < 3:
+                latent = styles[0].unsqueeze(1).repeat(1, inject_index, 1)
+            else:
+                latent = styles[0][:,:inject_index, :]
+            if styles[1].ndim < 3:
+                latent2 = styles[1].unsqueeze(1).repeat(1, self.n_latent - inject_index, 1)
+            else:
+                latent2 = styles[1][:,inject_index:,:]
 
             latent = torch.cat([latent, latent2], 1)
 


### PR DESCRIPTION
Currently projected latent spaces give error when try to mix styles due to them being 18x512 when the code expects them to be 512. I think I fixed it the correct way yet I can not say I entirely understand StyleGan so it might be wrong but it gives me okay results.