### PR TITLE
fixed to allow multiple projections

### DIFF
--- a/projector.py
+++ b/projector.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
 
     noises = g_ema.make_noise()
 
-    latent_in = latent_mean.detach().clone().unsqueeze(0)
+    latent_in = latent_mean.detach().clone().unsqueeze(0).repeat(imgs.shape[0], 1)
 
     if args.w_plus:
         latent_in = latent_in.unsqueeze(1).repeat(1, g_ema.n_latent, 1)


### PR DESCRIPTION
It was not possible to project multiple files (unlike what's mentioned in the readme) because there was only one initial latent code (instead of one for each projected file).
(issue: https://github.com/rosinality/stylegan2-pytorch/issues/87)