### PR TITLE
Save image as JPG instead of PNG

### DIFF
--- a/apply_factor.py
+++ b/apply_factor.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
 
     grid = utils.save_image(
         torch.cat([img1, img, img2], 0),
-        f"{args.out_prefix}_index-{args.index}_degree-{args.degree}.png",
+        f"{args.out_prefix}_index-{args.index}_degree-{args.degree}.jpg",
         normalize=True,
         range=(-1, 1),
         nrow=args.n_sample,


### PR DESCRIPTION
This is a minor change, and maybe just a matter of personal preference.

I don't think it makes sense to save in a lossless format the output of some scripts, here `apply_factor.py`. For instance, for 50 eigenvectors and 10 samples of size 256x256, I get a folder of 50 PNG for a total of ~150 MB. If I use JPG instead of PNG, the total is ~25 MB, so 6 times less.

Here is a comparison between two archives, one with PNG, the other with JPG.
![comparison of folders](https://i.imgur.com/QKHfb9Q.png)