### PR TITLE
Ease the visualization of latent directions

### DIFF
--- a/apply_factor.py
+++ b/apply_factor.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 
     direction = eigvec[:, args.index].unsqueeze(0)
 
-    img_list = []
+    img_dict = dict()
 
     for u in torch.linspace(- args.degree, args.degree, args.d_num):
 
@@ -84,12 +84,24 @@ if __name__ == "__main__":
             input_is_latent=True,
         )
 
-        img_list.append(img_batch)
+        for j in range(img_batch.shape[0]):
+
+            img = img_batch[j].unsqueeze(0)
+
+            try:
+                img_dict[j].append(img)
+            except KeyError:
+                img_dict[j] = [img]
+
+    img_list = [
+        torch.cat(img_dict[j], 0)
+        for j in range(args.n_sample)
+    ]
 
     grid = utils.save_image(
         torch.cat(img_list, 0),
         f"{args.out_prefix}_index-{args.index}_degree-{args.degree}.png",
         normalize=True,
         range=(-1, 1),
-        nrow=args.n_sample,
+        nrow=args.d_num,
     )

--- a/apply_factor.py
+++ b/apply_factor.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
 
     img_dict = dict()
 
-    for u in torch.linspace(- args.degree, args.degree, args.d_num):
+    for u in torch.linspace(- args.degree, args.degree, args.degree_num):
 
         img_batch, _ = g(
             [latent + u * direction],
@@ -103,5 +103,5 @@ if __name__ == "__main__":
         f"{args.out_prefix}_index-{args.index}_degree-{args.degree}.png",
         normalize=True,
         range=(-1, 1),
-        nrow=args.d_num,
+        nrow=args.degree_num,
     )

--- a/apply_factor.py
+++ b/apply_factor.py
@@ -27,6 +27,13 @@ if __name__ == "__main__":
         default=2,
         help='channel multiplier factor. config-f = 2, else = 1',
     )
+    parser.add_argument(
+        "-d_num",
+        "--degree_num",
+        type=int,
+        default=3,
+        help="number of scalar factors for moving latent vectors along eigenvector",
+    )
     parser.add_argument("--ckpt", type=str, required=True, help="stylegan2 checkpoints")
     parser.add_argument(
         "--size", type=int, default=256, help="output image size of the generator"
@@ -64,29 +71,23 @@ if __name__ == "__main__":
     latent = torch.randn(args.n_sample, 512, device=args.device)
     latent = g.get_latent(latent)
 
-    direction = args.degree * eigvec[:, args.index].unsqueeze(0)
+    direction = eigvec[:, args.index].unsqueeze(0)
 
-    img, _ = g(
-        [latent],
-        truncation=args.truncation,
-        truncation_latent=trunc,
-        input_is_latent=True,
-    )
-    img1, _ = g(
-        [latent + direction],
-        truncation=args.truncation,
-        truncation_latent=trunc,
-        input_is_latent=True,
-    )
-    img2, _ = g(
-        [latent - direction],
-        truncation=args.truncation,
-        truncation_latent=trunc,
-        input_is_latent=True,
-    )
+    img_list = []
+
+    for u in torch.linspace(- args.degree, args.degree, args.d_num):
+
+        img_batch, _ = g(
+            [latent + u * direction],
+            truncation=args.truncation,
+            truncation_latent=trunc,
+            input_is_latent=True,
+        )
+
+        img_list.append(img_batch)
 
     grid = utils.save_image(
-        torch.cat([img1, img, img2], 0),
+        torch.cat(img_list, 0),
         f"{args.out_prefix}_index-{args.index}_degree-{args.degree}.png",
         normalize=True,
         range=(-1, 1),


### PR DESCRIPTION
There are two changes:
-   a CLI argument to be more generic, which lets us sample more than 3 points, compared to:

https://github.com/rosinality/stylegan2-pytorch/blob/7be6e64fc897c5a1df084c9dcc635479c88b2a2f/apply_factor.py#L61-L83

-   a transposition of the grid of results as I think it makes more sense to show one sample per row (instead of per column).

This is what the transposed results look like:
![transposed grid of results](https://i.imgur.com/fg5DJ8F.jpg)

NB: I have submitted a bunch of PR. I have merged all of them in one of my branch for my personal use:
https://github.com/woctezuma/stylegan2-pytorch/tree/quality-of-life-merge
In case you want to merge most of them, this would make it easier for you. Just let me know and I would submit a PR.