### PR TITLE
Fixed Truncation being limited in Generator

### DIFF
--- a/model.py
+++ b/model.py
@@ -481,7 +481,7 @@ class Generator(nn.Module):
                     getattr(self.noises, f"noise_{i}") for i in range(self.num_layers)
                 ]
 
-        if truncation < 1:
+        if truncation > 0.0:
             style_t = []
 
             for style in styles:


### PR DESCRIPTION
Previously truncation values bigger than 1.0 were ignored, leading to inconsistencies between Nvidia's TF implementation and this version.
It seems this line was last changed [here](https://github.com/rosinality/stylegan2-pytorch/commit/5f60e58a159349a222fac3ffcc3dd7246c03ed3d#diff-fada037ad086638e65c7ae77e3d223963e9afaa26326aab0ea718f4013176e43R442), although I don't completely understand why this was done, so please check this before merging.

Other than that thanks a lot for the repo :+1: 