### PR TITLE
Add easy link for converted weight file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ For example, if you cloned repositories in ~/stylegan2 and downloaded stylegan2-
 
 This will create converted stylegan2-ffhq-config-f.pt file.
 
+Alternatively, the stylegan2-ffhq-config-f.pt can be found at https://drive.google.com/file/d/1EC34VzQ-7W6X1t9az-GEFOWX1uYPpW8w/view.
+
 ### Generate samples
 
 > python generate.py --sample N_FACES --pics N_PICS --ckpt PATH_CHECKPOINT


### PR DESCRIPTION
Running the convert_weight.py script has lots of dependency issues (e.g the original stylegan2 uses Tensorflow 1.x). Hopefully this makes the process of getting the script to work less painful for others, who just want the pretrained model.