### PR TITLE
Replace 'range' with 'range_value' to suppress the deprecation warning

### DIFF
--- a/apply_factor.py
+++ b/apply_factor.py
@@ -89,6 +89,6 @@ if __name__ == "__main__":
         torch.cat([img1, img, img2], 0),
         f"{args.out_prefix}_index-{args.index}_degree-{args.degree}.png",
         normalize=True,
-        range=(-1, 1),
+        range_value=(-1, 1),
         nrow=args.n_sample,
     )

--- a/convert_weight.py
+++ b/convert_weight.py
@@ -297,5 +297,5 @@ if __name__ == "__main__":
     print(img_diff.abs().max())
 
     utils.save_image(
-        img_concat, name + ".png", nrow=n_sample, normalize=True, range=(-1, 1)
+        img_concat, name + ".png", nrow=n_sample, normalize=True, range_value=(-1, 1)
     )

--- a/generate.py
+++ b/generate.py
@@ -22,7 +22,7 @@ def generate(args, g_ema, device, mean_latent):
                 f"sample/{str(i).zfill(6)}.png",
                 nrow=1,
                 normalize=True,
-                range=(-1, 1),
+                range_value=(-1, 1),
             )
 
 

--- a/train.py
+++ b/train.py
@@ -311,7 +311,7 @@ def train(args, loader, generator, discriminator, g_optim, d_optim, g_ema, devic
                         f"sample/{str(i).zfill(6)}.png",
                         nrow=int(args.n_sample ** 0.5),
                         normalize=True,
-                        range=(-1, 1),
+                        range_value=(-1, 1),
                     )
 
             if i % 10000 == 0:


### PR DESCRIPTION
use range_value argument instead of range argument as it's being
deprecated
