### PR TITLE
fix: Fix bugs in FID calculation

### DIFF
--- a/fid.py
+++ b/fid.py
@@ -17,12 +17,15 @@ def extract_feature_from_samples(
 ):
     n_batch = n_sample // batch_size
     resid = n_sample - (n_batch * batch_size)
-    batch_sizes = [batch_size] * n_batch + [resid]
+    if resid == 0:
+        batch_sizes = [batch_size] * n_batch
+    else:
+        batch_sizes = [batch_size] * n_batch + [resid]
     features = []
 
     for batch in tqdm(batch_sizes):
         latent = torch.randn(batch, 512, device=device)
-        img, _ = g([latent], truncation=truncation, truncation_latent=truncation_latent)
+        img, _ = generator([latent], truncation=truncation, truncation_latent=truncation_latent)
         feat = inception(img)[0].view(img.shape[0], -1)
         features.append(feat.to("cpu"))
 


### PR DESCRIPTION
This PR fixes two subtle bugs:
1. In the current code, when `resid` (equals to `n_sample % batch_size`) is 0, the program exits in the last iteration throwing just "Floating point exception".
2. `g` in the `extract_feature_from_samples` is supposed to refer the argument `generator` (currently unused)